### PR TITLE
Add "attester" service that creates in-toto metadata + several improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frédéric Pierret <frederic.pierret@qubes-os.org>
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y git rsync celery python3-requests python3-celery \
         python3-packaging python3-mongoengine python3-pip python3-apt python3-debian \
-        python3-matplotlib python3-numpy python3-redis && \
+        python3-matplotlib python3-numpy python3-redis python3-jinja2 && \
     apt-get clean all
 RUN mkdir /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ For example, here is the one used by `notset-rebuilder`:
 [DEFAULT]
 broker = redis://broker:6379/0
 backend = mongodb://backend:27017
-snapshot = http://debian.notset.fr/snapshot
+snapshot = http://snapshot.notset.fr
 
 # Scheduled task period for fetching latest buildinfo files
 schedule = 1800

--- a/app/celery.py
+++ b/app/celery.py
@@ -36,9 +36,8 @@ celery_app_conf = {
     'task_routes': {
         'app.tasks.rebuilder.get': {'queue': 'get'},
         'app.tasks.rebuilder.rebuild': {'queue': 'rebuild'},
-        'app.tasks.rebuilder.record': {'queue': 'record'},
+        'app.tasks.rebuilder.attest': {'queue': 'attest'},
         'app.tasks.rebuilder.upload': {'queue': 'upload'},
-        'app.tasks.rebuilder.state': {'queue': 'state'},
         'app.tasks.rebuilder.fail': {'queue': 'fail'},
     }
 }

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -40,7 +40,7 @@ if 'CELERY_BROKER_URL' in os.environ:
 if 'CELERY_RESULT_BACKEND' in os.environ:
     broker = os.environ['CELERY_RESULT_BACKEND']
 
-snapshot = config.get('DEFAULT', 'snapshot', fallback='http://debian.notset.fr/snapshot')
+snapshot = config.get('DEFAULT', 'snapshot', fallback='http://snapshot.notset.fr')
 
 try:
     schedule = int(config.get('DEFAULT', 'schedule', fallback=DEFAULT_SCHEDULE))

--- a/app/libs/attester.py
+++ b/app/libs/attester.py
@@ -1,0 +1,54 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2021 Frédéric Pierret (fepitre) <frederic.pierret@qubes-os.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import subprocess
+
+try:
+    import koji
+except ImportError:
+    koji = None
+try:
+    import debian.debian_support
+except ImportError:
+    debian = None
+
+from app.libs.exceptions import RebuilderExceptionAttest
+from app.libs.rebuilder import getRebuilder
+
+
+def generate_intoto_metadata(output, gpg_sign_keyid, buildinfo):
+    new_files = [f['name'] for f in buildinfo['checksums-sha256']
+                 if not f['name'].endswith('.dsc')]
+    cmd = [
+              "in-toto-run", "--step-name=rebuild", "--no-command",
+              "--products"
+          ] + list(new_files)
+    cmd += ["--gpg", gpg_sign_keyid]
+    try:
+        subprocess.run(cmd, cwd=output, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise RebuilderExceptionAttest(f"in-toto metadata generation failed: {str(e)}")
+
+
+def get_intoto_metadata_output_dir(package, unreproducible=False):
+    builder = getRebuilder(package=package)
+    output_dir = f"/rebuild/{builder.distdir}"
+    sources = 'unreproducible/sources' if unreproducible else 'sources'
+    return f"{output_dir}/{sources}/{package.name}/{package.version}"

--- a/app/libs/common.py
+++ b/app/libs/common.py
@@ -25,7 +25,8 @@ DEBIAN = {
     "bullseye": "11",
     "bookworm": "12",
     "trixie": "13",
-    "unstable": ""
+    "sid": "unstable",
+    "unstable": "sid"
 }
 
 DEBIAN_ARCHES = {
@@ -43,7 +44,7 @@ def is_fedora(dist):
 
 
 def is_debian(dist):
-    dist, package_sets = "{}+".format(dist).split('+', 1)
+    dist, package_sets = f"{dist}+".split('+', 1)
     return DEBIAN.get(dist, None) is not None
 
 

--- a/app/libs/common.py
+++ b/app/libs/common.py
@@ -82,3 +82,14 @@ def get_backend_tasks(app):
             r[f] = value
         results.append(r)
     return results
+
+
+def delete_backend_tasks(app, status):
+    backend = app.backend
+    col = backend.collection.find()
+    results = []
+    for _, doc in enumerate(col):
+        if doc["status"] == status:
+            backend.collection.delete_one({"_id": doc["_id"]})
+            results.append(doc)
+    return results

--- a/app/libs/common.py
+++ b/app/libs/common.py
@@ -24,6 +24,7 @@ DEBIAN = {
     "buster": "10",
     "bullseye": "11",
     "bookworm": "12",
+    "trixie": "13",
     "unstable": ""
 }
 

--- a/app/libs/exceptions.py
+++ b/app/libs/exceptions.py
@@ -39,5 +39,5 @@ class RebuilderExceptionBuild(RebuilderException):
     pass
 
 
-class RebuilderExceptionRecord(RebuilderException):
+class RebuilderExceptionAttest(RebuilderException):
     pass

--- a/app/libs/getter.py
+++ b/app/libs/getter.py
@@ -73,8 +73,8 @@ def rebuild_task_parser(task):
     elif (task["status"] == 'FAILURE' or task["status"] == 'RETRY') \
             and task["result"]["exc_type"] == "RebuilderExceptionBuild":
         # We have stored package info in exception
-        parsed_task = task["result"]["exc_message"][0]
-        parsed_task["status"] = task["status"].lower()
+        parsed_task = [task["result"]["exc_message"][0]]
+        parsed_task[0]["status"] = task["status"].lower()
     return parsed_task
 
 
@@ -84,8 +84,9 @@ def get_rebuilt_packages(app):
     for task in tasks:
         parsed_task = rebuild_task_parser(task)
         if parsed_task:
-            package = BuildPackage.from_dict(parsed_task)
-            parsed_packages.append(package)
+            for p in parsed_task:
+                package = BuildPackage.from_dict(p)
+                parsed_packages.append(package)
     return parsed_packages
 
 
@@ -124,9 +125,11 @@ class RebuilderDist:
 
 
 class BuildPackage(dict):
-    def __init__(self, name, epoch, version, arch, dist, url, status="", log="", retries=0):
+    def __init__(self, name, epoch, version, arch, dist, url,
+                 artifacts="", status="", log="", retries=0):
         dict.__init__(self, name=name, epoch=epoch, version=version, arch=arch,
-                      dist=dist, url=url, status=status, log=log, retries=retries)
+                      dist=dist, url=url, artifacts=artifacts, status=status,
+                      log=log, retries=retries)
 
     def __getattr__(self, item):
         return self[item]

--- a/app/libs/getter.py
+++ b/app/libs/getter.py
@@ -110,7 +110,7 @@ class RebuilderDist:
             self.repo = FedoraRepository(self.name)
             self.package_sets = []
             self.distribution = "fedora"
-        elif is_debian(dist):
+        elif is_debian(self.name):
             self.name, package_sets = "{}+".format(self.name).split('+', 1)
             self.package_sets = [pkg_set for pkg_set in package_sets.split('+')
                                  if pkg_set]

--- a/app/libs/rebuilder.py
+++ b/app/libs/rebuilder.py
@@ -79,9 +79,9 @@ class DebianRebuilder(BaseRebuilder):
         self.distdir = f"debian"
         self.basedir = f"{self.artifacts_dir}/{self.distdir}"
         self.snapshot_query_url = kwargs.get(
-            'snapshot_query_url', 'http://debian.notset.fr/snapshot')
+            'snapshot_query_url', 'http://snapshot.notset.fr')
         self.snapshot_mirror = kwargs.get(
-            'snapshot_mirror', "http://debian.notset.fr/snapshot")
+            'snapshot_mirror', "http://snapshot.notset.fr")
         self.extra_build_args = None
 
     def debrebuild(self, tempdir):

--- a/app/libs/rebuilder.py
+++ b/app/libs/rebuilder.py
@@ -20,11 +20,8 @@
 
 import os
 import subprocess
-import shutil
-import glob
 import time
 import tempfile
-import debian.deb822
 
 from app.libs.common import is_qubes, is_debian, is_fedora
 from app.libs.exceptions import RebuilderExceptionBuild
@@ -59,15 +56,16 @@ class BaseRebuilder:
     def __init__(self, package, **kwargs):
         self.package = package
         self.sign_keyid = kwargs.get('sign_keyid', None)
-        self.logfile = "{}-{}.log".format(package, str(int(time.time())))
+        self.logfile = f"{package}-{str(int(time.time()))}.log"
+        self.artifacts_dir = "/artifacts"
 
-    def gen_temp_dir(self):
+    def gen_temp_dir(self, dir):
+        os.makedirs(dir, exist_ok=True)
         tempdir = tempfile.mkdtemp(
-            prefix='{}-{}'.format(self.package.name, self.package.version))
+            dir=dir,
+            prefix=f"{self.package.name}-{self.package.version}",
+        )
         return tempdir
-
-    def get_output_dir(self):
-        pass
 
 
 class FedoraRebuilder:
@@ -79,23 +77,13 @@ class DebianRebuilder(BaseRebuilder):
     def __init__(self, package, **kwargs):
         super().__init__(package, **kwargs)
         self.logfile = "debian-{}".format(self.logfile)
-        self.basedir = "/rebuild/debian"
+        self.distdir = f"debian"
+        self.basedir = f"{self.artifacts_dir}/{self.distdir}"
         self.snapshot_query_url = kwargs.get(
             'snapshot_query_url', 'http://debian.notset.fr/snapshot')
         self.snapshot_mirror = kwargs.get(
             'snapshot_mirror', "http://debian.notset.fr/snapshot")
         self.extra_build_args = None
-
-    def get_output_dir(self, unreproducible=False):
-        sources = 'sources'
-        if unreproducible:
-            sources = 'unreproducible/sources'
-        return '{}/{}/{}/{}'.format(
-            self.basedir,
-            sources,
-            self.package.name,
-            self.package.version
-        )
 
     def debrebuild(self, tempdir):
         # WIP: use internal Rebuilder class instead of wrapping through shell
@@ -122,64 +110,33 @@ class DebianRebuilder(BaseRebuilder):
         return result, build_cmd
 
     def run(self):
-        outputdir = None
         try:
-            tempdir = self.gen_temp_dir()
+            tempdir = self.gen_temp_dir(self.basedir)
             result, build_cmd = self.debrebuild(tempdir)
 
-            if result.returncode == 0:
-                self.logfile = f'{self.basedir}/log-ok/{self.logfile}'
-                self.package.status = "reproducible"
-            elif result.returncode == 2:
-                self.logfile = f'{self.basedir}/log-ok-unreproducible/{self.logfile}'
-                self.package.status = "unreproducible"
-            else:
-                self.logfile = f'{self.basedir}/log-fail/{self.logfile}'
-
+            self.logfile = f'{self.basedir}/{self.logfile}'
             os.makedirs(os.path.dirname(self.logfile), exist_ok=True)
             with open(self.logfile, 'wb') as fd:
                 fd.write(result.stdout)
 
+            self.package.artifacts = tempdir
+
             # This is for recording logfile entry into DB
             self.package.log = self.logfile
+
+            if result.returncode == 0:
+                self.package.status = "reproducible"
+            elif result.returncode == 2:
+                self.package.status = "unreproducible"
 
             if result.returncode not in (0, 2):
                 raise subprocess.CalledProcessError(
                     result.returncode, build_cmd)
 
-            os.chdir(tempdir)
-            buildinfo = glob.glob("{}*.buildinfo".format(self.package.name))[0]
-            link = glob.glob("rebuild*.link")[0]
-
-            # create final output directory
-            outputdir = self.get_output_dir(
-                unreproducible=result.returncode == 2)
-            os.makedirs(outputdir, exist_ok=True)
-            shutil.copy2(
-                os.path.join(tempdir, buildinfo), outputdir)
-            shutil.copy2(os.path.join(tempdir, link), outputdir)
-            shutil.rmtree(tempdir)
-
-            # create symlink to new buildinfo and rebuild link file
-            os.chdir(outputdir)
-            if buildinfo:
-                os.symlink(buildinfo, "buildinfo")
-            os.symlink(link, "metadata")
-
-            with open(buildinfo) as fd:
-                parsed_buildinfo = debian.deb822.BuildInfo(fd)
-
-            os.chdir(os.path.join(outputdir, '../../'))
-            for binpkg in parsed_buildinfo.get_binary():
-                if not os.path.exists(binpkg):
-                    os.symlink(self.package.name, binpkg)
-
             return self.package
         except (subprocess.CalledProcessError, FileNotFoundError,
-                FileExistsError, IndexError, OSError) as e:
-            if outputdir and os.path.exists(outputdir):
-                shutil.rmtree(outputdir)
-            raise RebuilderExceptionBuild(dict(self.package))
+                FileExistsError, IndexError, OSError):
+            raise RebuilderExceptionBuild([dict(self.package)])
 
 
 class QubesRebuilderRPM(FedoraRebuilder):
@@ -192,7 +149,8 @@ class QubesRebuilderDEB(DebianRebuilder):
         super().__init__(package, **kwargs)
         qubes_release, package_set, _ = \
             package.dist.lstrip('qubes-').split('-', 2)
-        self.basedir = f'/rebuild/qubes/deb/r{qubes_release}/{package_set}'
+        self.distdir = f"qubes/deb/r{qubes_release}/{package_set}"
+        self.basedir = f"{self.artifacts_dir}/{self.distdir}"
         self.logfile = self.logfile.replace('debian-', '')
         self.extra_build_args = [
             "--gpg-verify",

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -27,7 +27,7 @@ from packaging.version import parse as parse_version
 from jinja2 import Template
 
 from app.libs.logger import log
-from app.libs.common import get_celery_queued_tasks
+from app.libs.common import get_celery_queued_tasks, get_celery_unacked_tasks
 from app.config.config import Config
 from app.libs.exceptions import RebuilderExceptionDist, RebuilderException
 from app.libs.getter import RebuilderDist, get_rebuilt_packages, BuildPackage
@@ -69,7 +69,8 @@ def func(pct, allvals):
 
 def generate_results(app):
     rebuild_results = get_rebuilt_packages(app)
-    running_rebuilds = [BuildPackage.from_dict(p) for p in get_celery_queued_tasks(app, "unacked")]
+    running_rebuilds = [BuildPackage.from_dict(p) for p in get_celery_unacked_tasks(app)
+                        if isinstance(p, dict)]
     try:
         for dist in Config['dist'].split():
             dist = RebuilderDist(dist)

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -109,17 +109,17 @@ def generate_results(app):
                         if latest_results[package.name]["status"] == "reproducible":
                             pkg["badge"] = "https://img.shields.io/badge/-success-success"
                             if pkg["log"]:
-                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
+                                pkg["log"] = f'{os.path.dirname(pkg["log"]).replace(f"/artifacts/{dist.distribution}", "..")}/log-ok/{os.path.basename(pkg["log"])}'
                             result["reproducible"].append(pkg)
                         elif latest_results[package.name]["status"] == "unreproducible":
                             pkg["badge"] = "https://img.shields.io/badge/-unreproducible-yellow"
                             if pkg["log"]:
-                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
+                                pkg["log"] = f'{os.path.dirname(pkg["log"]).replace(f"/artifacts/{dist.distribution}", "..")}/log-ok-unreproducible/{os.path.basename(pkg["log"])}'
                             result["unreproducible"].append(pkg)
                         elif latest_results[package.name]["status"] == "failure":
                             pkg["badge"] = "https://img.shields.io/badge/-failure-red"
                             if pkg["log"]:
-                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
+                                pkg["log"] = f'{os.path.dirname(pkg["log"]).replace(f"/artifacts/{dist.distribution}", "..")}/log-fail/{os.path.basename(pkg["log"])}'
                             result["failure"].append(pkg)
                         elif latest_results[package.name]["status"] == "retry":
                             pkg["badge"] = "https://img.shields.io/badge/-pending-lightgrey"

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -174,5 +174,5 @@ def generate_results(app):
             with open(f"{results_path}/{dist.name}.{dist.arch}.html", 'w') as fd:
                 fd.write(HTML_TEMPLATE.render(**data))
 
-    except (RebuilderExceptionDist, FileNotFoundError, ValueError) as e:
+    except Exception as e:
         raise RebuilderException("{}: failed to generate status.".format(str(e)))

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -104,17 +104,17 @@ def generate_results(app):
                         if latest_results[package.name]["status"] == "reproducible":
                             pkg["badge"] = "https://img.shields.io/badge/-success-success"
                             if pkg["log"]:
-                                pkg["log"] = f'../log-ok/{os.path.basename(pkg["log"])}'
+                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
                             result["reproducible"].append(pkg)
                         elif latest_results[package.name]["status"] == "unreproducible":
                             pkg["badge"] = "https://img.shields.io/badge/-unreproducible-yellow"
                             if pkg["log"]:
-                                pkg["log"] = f'../log-ok-unreproducible/{os.path.basename(pkg["log"])}'
+                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
                             result["unreproducible"].append(pkg)
                         elif latest_results[package.name]["status"] == "failure":
                             pkg["badge"] = "https://img.shields.io/badge/-failure-red"
                             if pkg["log"]:
-                                pkg["log"] = f'../log-fail/{os.path.basename(pkg["log"])}'
+                                pkg["log"] = pkg["log"].replace(f"/artifacts/{dist.distribution}/", "../")
                             result["failure"].append(pkg)
                         elif latest_results[package.name]["status"] == "retry":
                             pkg["badge"] = "https://img.shields.io/badge/-pending-lightgrey"

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -1,0 +1,180 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2021 Frédéric Pierret (fepitre) <frederic.pierret@qubes-os.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import os
+import requests
+import numpy as np
+import matplotlib.pyplot as plt
+
+from packaging.version import parse as parse_version
+from jinja2 import Template
+
+from app.libs.logger import log
+from app.config.config import Config
+from app.libs.exceptions import RebuilderExceptionDist, RebuilderException
+from app.libs.getter import RebuilderDist, get_rebuilt_packages
+
+HTML_TEMPLATE = Template("""<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <title>{{dist}} rebuild status</title>
+  <style>
+  body { font-family: sans-serif; }
+  td, th { border: solid 2px #dcdcdc; padding: 4px; }
+  table { border-collapse: collapse; }
+  </style>
+</head>
+<body>
+
+<h1 id="dist">{{dist}}</h1>
+
+{%- for package_set, packages in summary.items() -%}
+<h3 id="{{package_set}}">{{package_set}}</h3>
+<tbody>
+<table>
+{%- for pkg in packages %}
+<tr><td>{{pkg['name']}}-{{pkg['version']}}</td><td align="center"><a href="{{pkg['log']}}"><img src="{{pkg['badge']}}" alt="{{pkg['status']}}"/></a></td></tr>
+{%- endfor %}
+</table>
+</tbody>
+{%- endfor %}
+</body>
+</html>
+""")
+
+
+def func(pct, allvals):
+    absolute = round(pct / 100. * np.sum(allvals))
+    return "{:.1f}%\n({:d})".format(pct, absolute)
+
+
+def generate_results(app):
+    html_summary = {}
+    rebuild_results = get_rebuilt_packages(app)
+    try:
+        for dist in Config['dist'].split():
+            dist = RebuilderDist(dist)
+            results_path = f"/rebuild/{dist.distribution}/results"
+            os.makedirs(results_path, exist_ok=True)
+
+            # Get results for given dist
+            results = [x for x in rebuild_results
+                       if x['dist'] == dist.name and x['arch'] == dist.arch]
+
+            # Filter latest results
+            latest_results = {}
+            for r in results:
+                if latest_results.get(r["name"], None):
+                    if parse_version(r["version"]) <= parse_version(latest_results[r["name"]]["version"]):
+                        continue
+                latest_results[r["name"]] = r
+
+            # Get BuildPackages that go into rebuild
+            packages_list = dist.repo.get_buildpackages(dist.arch)
+
+            # Filter results per status on every package sets
+            for pkgset_name in dist.package_sets:
+                # Get packages in a given set
+                if dist.distribution == "debian":
+                    packages_in_set = dist.repo.get_packages_set(pkgset_name)
+                else:
+                    packages_in_set = latest_results.keys()
+
+                # Prepare the result data
+                result = {"reproducible": [], "unreproducible": [], "failure": [], "pending": []}
+                html_summary[pkgset_name] = []
+                for pkg_name in packages_in_set:
+                    if pkg_name not in packages_list.keys():
+                        continue
+                    if latest_results.get(pkg_name, {}) in packages_list[pkg_name]:
+                        pkg = latest_results[pkg_name]
+                        if latest_results[pkg_name]["status"] == "reproducible":
+                            pkg["badge"] = "https://img.shields.io/badge/-success-success"
+                            if pkg["log"]:
+                                pkg["log"] = f'../log-ok/{os.path.basename(pkg["log"])}'
+                            result["reproducible"].append(pkg)
+                        elif latest_results[pkg_name]["status"] == "unreproducible":
+                            pkg["badge"] = "https://img.shields.io/badge/-unreproducible-yellow"
+                            if pkg["log"]:
+                                pkg["log"] = f'../log-ok-unreproducible/{os.path.basename(pkg["log"])}'
+                            result["unreproducible"].append(pkg)
+                        elif latest_results[pkg_name]["status"] == "failure":
+                            pkg["badge"] = "https://img.shields.io/badge/-failure-red"
+                            if pkg["log"]:
+                                pkg["log"] = f'../log-fail/{os.path.basename(pkg["log"])}'
+                            result["failure"].append(pkg)
+                        elif latest_results[pkg_name]["status"] == "retry":
+                            pkg["badge"] = "https://img.shields.io/badge/-pending-lightgrey"
+                            pkg["status"] = "pending"
+                            result["pending"].append(pkg)
+                    else:
+                        pkg = packages_list[pkg_name][0]
+                        pkg["badge"] = "https://img.shields.io/badge/-pending-lightgrey"
+                        result["pending"].append(pkg)
+
+                # We simplify how we render HTML
+                for packages in result.values():
+                    html_summary[pkgset_name] += packages
+
+                x = []
+                legends = []
+                explode = []
+                colors = []
+                if result["reproducible"]:
+                    count = len(result["reproducible"])
+                    x.append(count)
+                    legends.append(f"Reproducible")
+                    colors.append("green")
+                    explode.append(0)
+                if result["unreproducible"]:
+                    count = len(result["unreproducible"])
+                    x.append(count)
+                    legends.append(f"Unreproducible")
+                    colors.append("orange")
+                    explode.append(0)
+                if result["failure"]:
+                    count = len(result["failure"])
+                    x.append(count)
+                    legends.append(f"Failure")
+                    colors.append("red")
+                    explode.append(0)
+                if result["pending"]:
+                    count = len(result["pending"])
+                    x.append(count)
+                    legends.append(f"Pending")
+                    colors.append("grey")
+                    explode.append(0)
+
+                fig, ax = plt.subplots(figsize=(9, 6), subplot_kw=dict(aspect="equal"))
+                wedges, texts, autotexts = ax.pie(x, colors=colors, explode=explode, autopct=lambda pct: func(pct, x), shadow=True, startangle=90, normalize=True)
+                ax.legend(wedges, legends, title="Status", loc="center left", bbox_to_anchor=(1, 0, 0.5, 1))
+                ax.set(aspect="equal", title=f"{dist.name}+{pkgset_name}.{dist.arch}")
+                fig.savefig(f"{results_path}/{dist.name}_{pkgset_name}.{dist.arch}.png")
+                plt.close(fig)
+
+                # with open(f"{results_path}/{dist}_db.json", "w") as fd:
+                #     fd.write(json.dumps(latest_results, indent=2) + "\n")
+
+            data = {"dist": f"{dist.distribution} {dist.name} ({dist.arch})", "summary": html_summary}
+            with open(f"{results_path}/{dist.name}.{dist.arch}.html", 'w') as fd:
+                fd.write(HTML_TEMPLATE.render(**data))
+
+    except (RebuilderExceptionDist, FileNotFoundError, ValueError) as e:
+        raise RebuilderException("{}: failed to generate status.".format(str(e)))

--- a/app/libs/reporter.py
+++ b/app/libs/reporter.py
@@ -122,6 +122,8 @@ def generate_results(app):
                             result["pending"].append(pkg)
                     else:
                         pkg = package
+                        # On clean of FAILED tasks, previous info remains
+                        pkg["log"] = ""
                         pkg["badge"] = "https://img.shields.io/badge/-pending-lightgrey"
                         result["pending"].append(pkg)
 

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -41,6 +41,8 @@ from app.libs.attester import generate_intoto_metadata, get_intoto_metadata_outp
 class RebuilderTask(celery.Task):
     autoretry_for = (RebuilderExceptionBuild,)
     max_retries = Config['max_retries']
+    # Let snapshot service to get the latest data from official repositories
+    default_retry_delay = 60 * 60
 
 # TODO: improve serialize/deserialize Package
 

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -39,7 +39,7 @@ from app.libs.reporter import generate_results
 
 
 class RebuilderTask(celery.Task):
-    autoretry_for = (RebuilderExceptionBuild,)
+    autoretry_for = (RebuilderExceptionBuild, RebuilderExceptionUpload)
     max_retries = Config['max_retries']
     # Let snapshot service to get the latest data from official repositories
     default_retry_delay = 60 * 60

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -219,7 +219,7 @@ def get(dist):
                 elif os.path.exists(metadata_unrepr):
                     package.status = "unreproducible"
                 if package.status in ("reproducible", "unreproducible"):
-                    log.debug("{}: in-toto metadata already exists.".format(package))
+                    log.debug(f"{package}: already built ({package.status}). Skipping")
                     result.setdefault("rebuild", []).append(dict(package))
                     continue
 

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -96,19 +96,14 @@ def get(dist):
     else:
         try:
             dist = RebuilderDist(dist)
-            packages = dist.repo.get_buildpackages(dist.arch)
+            packages = dist.repo.get_packages_to_rebuild()
             if not packages:
                 log.debug(f"No packages found for {dist}")
 
             # get previous triggered packages builds
             stored_packages = get_rebuilt_packages(app)
 
-            for name in packages.keys():
-                if not packages[name]:
-                    log.debug(f"Nothing to build for package {name} ({dist})")
-                    continue
-                package = packages[name][0]
-
+            for package in packages:
                 # check if metadata exists
                 metadata = os.path.join(get_intoto_metadata_output_dir(package), 'metadata')
                 metadata_unrepr = os.path.join(

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -117,7 +117,7 @@ def get(dist):
                     log.debug(f"{package}: already submitted. Skipping.")
                     continue
 
-                if dict(package) not in get_celery_queued_tasks("rebuild"):
+                if dict(package) not in get_celery_queued_tasks(app, "rebuild"):
                     log.debug(f"{package}: submitted for rebuild.")
                     # Add rebuild task
                     rebuild.delay(package)

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -50,11 +50,21 @@ class RebuilderTask(celery.Task):
 
 def get_celery_queued_tasks(queue_name):
     with app.pool.acquire(block=True) as conn:
-        tasks = conn.default_channel.client.lrange(queue_name, 0, -1)
-        submitted_tasks = []
+        if queue_name == "unacked":
+            tasks = conn.default_channel.client.hvals(queue_name)
+        else:
+            tasks = conn.default_channel.client.lrange(queue_name, 0, -1)
 
+    submitted_tasks = []
     for task in tasks:
+        try:
+            if isinstance(task, bytes):
+                task = task.decode("utf-8")
+        except UnicodeDecodeError:
+            log.error("Failed to parse task")
         j = json.loads(task)
+        if j and isinstance(j, list):
+            j = j[0]
         body = json.loads(base64.b64decode(j['body']))
         submitted_tasks.append(body[0][0])
 

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -40,6 +40,7 @@ from app.libs.reporter import generate_results
 
 class RebuilderTask(celery.Task):
     autoretry_for = (RebuilderExceptionBuild, RebuilderExceptionUpload)
+    throws = (RebuilderException,)
     max_retries = Config['max_retries']
     # Let snapshot service to get the latest data from official repositories
     default_retry_delay = 60 * 60

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -105,6 +105,8 @@ def generate_results(app):
                         continue
                 data_ordered[x["name"]] = x
 
+            packages_list = dist.repo.get_buildpackages(dist.arch)
+
             for pkgset_name in dist.package_sets:
                 if dist.distribution == "debian":
                     url = f"https://jenkins.debian.net/userContent/reproducible/" \
@@ -118,12 +120,13 @@ def generate_results(app):
                         continue
                     content = resp.text.rstrip('\n').split('\n')
                 else:
-                    # fixme: for Qubes we need a list of packages
                     content = data_ordered.keys()
 
                 result = {"repro": [], "unrepro": [], "fail": [], "pending": []}
                 for pkg_name in content:
-                    if data_ordered.get(pkg_name, {}).get('status', None):
+                    if pkg_name not in packages_list.keys():
+                        continue
+                    if data_ordered.get(pkg_name, {}) in packages_list[pkg_name]:
                         if data_ordered[pkg_name]["status"] == "reproducible":
                             result["repro"].append(pkg_name)
                         elif data_ordered[pkg_name]["status"] == "unreproducible":

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -163,6 +163,7 @@ def generate_results(app):
                 ax.legend(wedges, legends, title="Status", loc="center left", bbox_to_anchor=(1, 0, 0.5, 1))
                 ax.set(aspect="equal", title=f"{dist.name}+{pkgset_name}.{dist.arch}")
                 fig.savefig(f"{results_path}/{dist.name}_{pkgset_name}.{dist.arch}.png")
+                plt.close(fig)
 
                 # with open(f"{results_path}/{dist}_db.json", "w") as fd:
                 #     fd.write(json.dumps(data_ordered, indent=2) + "\n")

--- a/app/tasks/rebuilder.py
+++ b/app/tasks/rebuilder.py
@@ -309,8 +309,10 @@ def attest(package):
 
     # create symlink to new buildinfo and rebuild link file
     os.chdir(outputdir)
-    os.symlink(buildinfo, "buildinfo")
-    os.symlink(link, "metadata")
+    if not os.path.exists("buildinfo"):
+        os.symlink(buildinfo, "buildinfo")
+    if not os.path.exists("metadata"):
+        os.symlink(link, "metadata")
 
     os.chdir(os.path.join(outputdir, '../../'))
     for binpkg in parsed_buildinfo.get_binary():
@@ -343,7 +345,9 @@ def upload(package):
     else:
         log_dir = f"{output_dir}/log-fail"
     os.makedirs(log_dir, exist_ok=True)
-    shutil.move(package.log, f"{log_dir}/{os.path.basename(package.log)}")
+    dst_log = f"{log_dir}/{os.path.basename(package.log)}"
+    if not os.path.exists(dst_log):
+        shutil.move(package.log, dst_log)
 
     # generate plots from results
     try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
     image: 'rebuilder_base'
     volumes:
       - .:/app
+# uploader worker needs in-toto directory for checking if metadata exists
+      - '/var/lib/rebuilder/rebuild:/rebuild'
     depends_on:
       - broker
       - backend
@@ -93,9 +95,8 @@ services:
       dockerfile: rebuilder.Dockerfile
     volumes:
       - .:/app
-# rebuilder worker(s) need(s) artifacts directory and GPG for signing in-toto metadata
-      - '/var/lib/rebuilder/rebuild:/rebuild'
-      - '/var/lib/rebuilder/gnupg:/root/.gnupg'
+# rebuilder worker(s) need(s) artifacts directory
+      - '/var/lib/rebuilder/artifacts:/artifacts'
     depends_on:
       - broker
       - backend
@@ -112,12 +113,37 @@ services:
 #      mode: replicated
 #      replicas: 2
 
+  attester:
+    restart: always
+    privileged: true
+    build:
+      context: .
+      dockerfile: rebuilder.Dockerfile
+    volumes:
+      - .:/app
+# attester need artifacts directory, in-toto repository and GPG for signing in-toto metadata
+      - '/var/lib/rebuilder/artifacts:/artifacts'
+      - '/var/lib/rebuilder/rebuild:/rebuild'
+      - '/var/lib/rebuilder/gnupg:/root/.gnupg'
+    depends_on:
+      - broker
+      - backend
+    links:
+      - broker
+      - backend
+    environment:
+      - CELERY_BROKER_URL=redis://broker:6379/0
+      - CELERY_RESULT_BACKEND=mongodb://backend:27017
+# https://docs.celeryproject.org/en/stable/reference/cli.html#cmdoption-celery-worker-c
+    entrypoint: celery -A app worker --loglevel=INFO  -O fair --prefetch-multiplier 1 -c 1 --queues=attest
+
   uploader:
     restart: always
     image: 'rebuilder_base'
     volumes:
       - .:/app
-# uploader worker needs artifacts directory and SSH key for rsyncing on remote location
+# uploader worker needs artifacts, in-toto directory and SSH key for rsyncing on remote location
+      - '/var/lib/rebuilder/artifacts:/artifacts'
       - '/var/lib/rebuilder/rebuild:/rebuild'
       - '/var/lib/rebuilder/ssh:/root/.ssh'
     depends_on:

--- a/rebuilder.Dockerfile
+++ b/rebuilder.Dockerfile
@@ -2,7 +2,7 @@ FROM rebuilder_base:latest
 MAINTAINER Frédéric Pierret <frederic.pierret@qubes-os.org>
 
 # REBUILDER
-RUN apt-get update && apt-get install -y mmdebstrap in-toto python3-dateutil python3-rstr python3-setuptools && apt-get clean all
+RUN apt-get update && apt-get install -y mmdebstrap in-toto python3-dateutil python3-rstr python3-setuptools debian-keyring debian-archive-keyring && apt-get clean all
 # Use upstream python-debian code
 # This is needed for libs/rebuilder.py when looping over binpkg in get_binary()
 RUN git clone https://salsa.debian.org/python-debian-team/python-debian /opt/python-debian

--- a/rebuilder.conf
+++ b/rebuilder.conf
@@ -1,7 +1,7 @@
 [DEFAULT]
 broker = redis://broker:6379/0
 backend = mongodb://backend:27017
-snapshot = http://debian.notset.fr/snapshot
+snapshot = http://snapshot.notset.fr
 
 # Scheduled task period for fetching latest buildinfo files
 schedule = 1800


### PR DESCRIPTION
We delegate the creation of `in-toto` metadata to a separate service. Currently, we relied on `fepitre/debrebuild` to generate in-toto metadata. One issue with that is we cannot plug external rebuilders without passing the private GPG key. From a security point of view this is not acceptable.

- [x] Update README